### PR TITLE
chore: simplify tsconfig paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,11 +20,7 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@/components/*": ["./src/components/*"],
-      "@/lib/*": ["./src/lib/*"],
-      "@/hooks/*": ["./src/hooks/*"],
-      "@/types/*": ["./src/types/*"]
+      "@/*": ["src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- simplify TSConfig path aliases to base `src` mapping

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run type-check` *(fails: numerous TS errors; missing modules)*
- `docker-compose build frontend` *(fails: command not found: docker-compose)*

------
https://chatgpt.com/codex/tasks/task_e_689a20faf9c88322858a44b8d575ab0c