### PR TITLE
fix: allow frontend docker build despite peer deps

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci --only=production
+RUN npm ci --omit=dev --legacy-peer-deps
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
## Summary
- relax npm install in frontend Dockerfile by ignoring peer dependency conflicts and dev deps

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a23bad0888322aa30d4dfe8944d7c